### PR TITLE
[BAAAS-296] enable/disable Kafka Integration via configuration

### DIFF
--- a/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/dfs/client/DecisionFleetShardClientFactory.java
+++ b/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/dfs/client/DecisionFleetShardClientFactory.java
@@ -35,12 +35,12 @@ import static java.util.Objects.requireNonNull;
 @ApplicationScoped
 public class DecisionFleetShardClientFactory {
 
-    private final DecisionFleetManagerConfig controlPlaneConfig;
+    private final DecisionFleetManagerConfig fmConfig;
 
     @Inject
     public DecisionFleetShardClientFactory(DecisionFleetManagerConfig config) {
         requireNonNull(config, "config cannot be null");
-        this.controlPlaneConfig = config;
+        this.fmConfig = config;
     }
 
     public DecisionFleetShardClient createClientFor(DecisionFleetShard fleetShard) {
@@ -48,6 +48,6 @@ public class DecisionFleetShardClientFactory {
         Config config = new ConfigBuilder().withMasterUrl(fleetShard.getKubernetesApiUrl()).build();
         KubernetesClient client = new DefaultKubernetesClient(config);
 
-        return new DefaultDecisionFleetShardClient(this.controlPlaneConfig, client, fleetShard);
+        return new DefaultDecisionFleetShardClient(this.fmConfig, client, fleetShard);
     }
 }

--- a/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/manager/DecisionLifecycleOrchestrator.java
+++ b/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/manager/DecisionLifecycleOrchestrator.java
@@ -21,6 +21,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.kie.baaas.dfm.api.decisions.DecisionRequest;
+import org.kie.baaas.dfm.api.eventing.Eventing;
 import org.kie.baaas.dfm.app.controller.modelmappers.DecisionMapper;
 import org.kie.baaas.dfm.app.dfs.DecisionFleetShardClient;
 import org.kie.baaas.dfm.app.dfs.DecisionFleetShardSelector;
@@ -30,7 +31,8 @@ import org.kie.baaas.dfm.app.event.AfterFailedEvent;
 import org.kie.baaas.dfm.app.event.BeforeCreateOrUpdateVersionEvent;
 import org.kie.baaas.dfm.app.exceptions.DecisionFleetManagerException;
 import org.kie.baaas.dfm.app.listener.ListenerManager;
-import org.kie.baaas.dfm.app.managedservices.ManagedServicesClient;
+import org.kie.baaas.dfm.app.manager.kafkaservice.KafkaServiceNotSupportedException;
+import org.kie.baaas.dfm.app.manager.kafkaservice.KafkaServiceProducer;
 import org.kie.baaas.dfm.app.model.Decision;
 import org.kie.baaas.dfm.app.model.DecisionFleetShard;
 import org.kie.baaas.dfm.app.model.DecisionVersion;
@@ -38,11 +40,6 @@ import org.kie.baaas.dfm.app.model.ListResult;
 import org.kie.baaas.dfm.app.model.deployment.Deployment;
 import org.kie.baaas.dfm.app.model.eventing.Credential;
 import org.kie.baaas.dfm.app.storage.DecisionDMNStorage;
-import org.kie.baaas.dfm.app.vault.Secret;
-import org.kie.baaas.dfm.app.vault.VaultService;
-
-import static org.kie.baaas.dfm.app.managedservices.ManagedServicesClient.CLIENT_ID;
-import static org.kie.baaas.dfm.app.managedservices.ManagedServicesClient.CLIENT_SECRET;
 
 /**
  * This class orchestrates a number of internal components to manage the lifecycle of a Decision.
@@ -51,8 +48,6 @@ import static org.kie.baaas.dfm.app.managedservices.ManagedServicesClient.CLIENT
  */
 @ApplicationScoped
 public class DecisionLifecycleOrchestrator implements DecisionLifecycle {
-
-    private static final String CREDENTIALS_NAME = "daas-%s-credentials";
 
     private final DecisionFleetShardClientFactory clientFactory;
 
@@ -66,25 +61,24 @@ public class DecisionLifecycleOrchestrator implements DecisionLifecycle {
 
     private final DecisionMapper decisionMapper;
 
-    private final VaultService vaultService;
+    private final KafkaServiceProducer kafkaServiceProducer;
 
-    private final ManagedServicesClient managedServicesClient;
+    private final KafkaService kafkaService;
 
     @Inject
     public DecisionLifecycleOrchestrator(DecisionFleetShardClientFactory clientFactory, DecisionFleetShardSelector fleetShardSelector, DecisionManager decisionManager,
             DecisionDMNStorage decisionDMNStorage,
             ListenerManager listenerManager,
-            DecisionMapper decisionMapper,
-            VaultService vaultService,
-            ManagedServicesClient managedServicesClient) {
+            DecisionMapper decisionMapper, KafkaService kafkaService,
+            KafkaServiceProducer kafkaServiceProducer) {
         this.clientFactory = clientFactory;
         this.fleetShardSelector = fleetShardSelector;
         this.decisionManager = decisionManager;
         this.decisionDMNStorage = decisionDMNStorage;
         this.listenerManager = listenerManager;
         this.decisionMapper = decisionMapper;
-        this.vaultService = vaultService;
-        this.managedServicesClient = managedServicesClient;
+        this.kafkaService = kafkaService;
+        this.kafkaServiceProducer = kafkaServiceProducer;
     }
 
     @Override
@@ -99,6 +93,11 @@ public class DecisionLifecycleOrchestrator implements DecisionLifecycle {
 
     @Override
     public DecisionVersion createOrUpdateVersion(String customerId, DecisionRequest decisionRequest) {
+        Eventing evt = decisionRequest.getEventing();
+        if (evt != null && evt.getKafka() != null && !kafkaServiceProducer.isKafkaServiceEnabled()) {
+            throw new KafkaServiceNotSupportedException("Kafka service is not supported in this environment.");
+        }
+
         listenerManager.notifyListeners(() -> new BeforeCreateOrUpdateVersionEvent(decisionRequest));
         // TODO - chicken and egg problem here.  The DecisionVersion requires information about the DMN
         // storage location, but the storage requires the DecisionVersion. We therefore have the write
@@ -107,9 +106,10 @@ public class DecisionLifecycleOrchestrator implements DecisionLifecycle {
         DecisionVersion decisionVersion = decisionManager.createOrUpdateVersion(customerId, decisionRequest);
 
         if (decisionVersion.getKafkaConfig() != null) {
-            Credential credential = getCustomerCredential(customerId, decisionRequest);
+            Credential credential = kafkaService.getCustomerCredential(customerId);
             decisionVersion.getKafkaConfig().setCredential(credential);
         }
+
         return requestDeployment(customerId, decisionVersion);
     }
 
@@ -202,27 +202,5 @@ public class DecisionLifecycleOrchestrator implements DecisionLifecycle {
     private DecisionFleetShardClient getFleetShardClient(Decision decision) {
         DecisionFleetShard fleetShard = fleetShardSelector.selectFleetShardForDeployment(decision);
         return clientFactory.createClientFor(fleetShard);
-    }
-
-    private Credential getCustomerCredential(String customerId, DecisionRequest decisionRequest) {
-        if (decisionRequest.getEventing() != null) {
-            String secretName = String.format(CREDENTIALS_NAME, customerId);
-            Secret secret = vaultService.get(secretName);
-            if (secret == null) {
-                secret = managedServicesClient.createOrReplaceServiceAccount(secretName);
-                vaultService.create(secret);
-            }
-            return toCredential(secret);
-        }
-        return null;
-    }
-
-    private Credential toCredential(Secret secret) {
-        if (secret == null || secret.getValues() == null) {
-            return null;
-        }
-        return new Credential()
-                .setClientId(secret.getValues().get(CLIENT_ID))
-                .setClientSecret(secret.getValues().get(CLIENT_SECRET));
     }
 }

--- a/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/manager/KafkaService.java
+++ b/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/manager/KafkaService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.kie.baaas.dfm.app.manager;
+
+import org.kie.baaas.dfm.app.model.eventing.Credential;
+
+public interface KafkaService {
+    /**
+     * This method connects to Kafka service, and creates/replaces service account.
+     * The credential of the service account is collected and stored in a vault.
+     */
+    Credential getCustomerCredential(String customerId);
+}

--- a/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/manager/kafkaservice/DisabledKafkaService.java
+++ b/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/manager/kafkaservice/DisabledKafkaService.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.kie.baaas.dfm.app.manager.kafkaservice;
+
+import org.kie.baaas.dfm.app.manager.KafkaService;
+import org.kie.baaas.dfm.app.model.eventing.Credential;
+
+/**
+ * This is a dummy class to be used when no valid kafka service is configured.
+ *
+ */
+public class DisabledKafkaService implements KafkaService {
+    @Override
+    public Credential getCustomerCredential(String customerId) {
+        throw new UnsupportedOperationException("DisabledKafkaService");
+    }
+}

--- a/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/manager/kafkaservice/KafkaServiceNotSupportedException.java
+++ b/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/manager/kafkaservice/KafkaServiceNotSupportedException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.kie.baaas.dfm.app.manager.kafkaservice;
+
+import javax.ws.rs.core.Response;
+
+import org.kie.baaas.dfm.app.exceptions.DecisionFleetManagerException;
+
+public class KafkaServiceNotSupportedException extends DecisionFleetManagerException {
+    public KafkaServiceNotSupportedException(String message) {
+        super(message);
+    }
+
+    public KafkaServiceNotSupportedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    @Override
+    public int getStatusCode() {
+        return Response.Status.BAD_REQUEST.getStatusCode();
+    }
+}

--- a/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/manager/kafkaservice/KafkaServiceProducer.java
+++ b/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/manager/kafkaservice/KafkaServiceProducer.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.kie.baaas.dfm.app.manager.kafkaservice;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.kie.baaas.dfm.app.exceptions.DecisionFleetManagerException;
+import org.kie.baaas.dfm.app.managedservices.ManagedServicesClient;
+import org.kie.baaas.dfm.app.manager.KafkaService;
+import org.kie.baaas.dfm.app.vault.VaultService;
+
+import io.quarkus.runtime.Startup;
+
+@ApplicationScoped
+public class KafkaServiceProducer {
+
+    private volatile KafkaServiceType type = KafkaServiceType.DISABLED;
+
+    @ConfigProperty(name = "baaas.dfm.kafka.service.type")
+    String serviceType;
+
+    @Inject
+    ManagedServicesClient msc;
+
+    @Inject
+    VaultService vaultService;
+
+    @Startup
+    @ApplicationScoped
+    public KafkaService produceKafkaService() {
+        KafkaService kc;
+        if (KafkaServiceType.OPERATE_FIRST.equalValue(serviceType)) {
+            kc = new OperateFirstKafkaService();
+            this.type = KafkaServiceType.OPERATE_FIRST;
+        } else if (KafkaServiceType.MANAGED_KAFKA.equalValue(serviceType)) {
+            kc = new ManagedKafkaService(msc, vaultService);
+            this.type = KafkaServiceType.MANAGED_KAFKA;
+        } else if (KafkaServiceType.DISABLED.equalValue(serviceType)) {
+            this.type = KafkaServiceType.DISABLED;
+            kc = new DisabledKafkaService();
+        } else {
+            throw new DecisionFleetManagerException(String.format("invalid kafka service type:%s, failed to produce Kafka Service.", serviceType));
+        }
+        return kc;
+    }
+
+    public boolean isKafkaServiceEnabled() {
+        return this.type != KafkaServiceType.DISABLED;
+    }
+}

--- a/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/manager/kafkaservice/KafkaServiceType.java
+++ b/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/manager/kafkaservice/KafkaServiceType.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.kie.baaas.dfm.app.manager.kafkaservice;
+
+public enum KafkaServiceType {
+    OPERATE_FIRST("operate-first-kafka"),
+    MANAGED_KAFKA("managed-kafka"),
+    DISABLED("disabled");
+
+    private final String name;
+
+    KafkaServiceType(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return this.name;
+    }
+
+    public boolean equalValue(String name) {
+        return this.name.equals(name);
+    }
+}

--- a/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/manager/kafkaservice/ManagedKafkaService.java
+++ b/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/manager/kafkaservice/ManagedKafkaService.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.kie.baaas.dfm.app.manager.kafkaservice;
+
+import org.kie.baaas.dfm.app.managedservices.ManagedServicesClient;
+import org.kie.baaas.dfm.app.manager.KafkaService;
+import org.kie.baaas.dfm.app.model.eventing.Credential;
+import org.kie.baaas.dfm.app.vault.Secret;
+import org.kie.baaas.dfm.app.vault.VaultService;
+
+import static org.kie.baaas.dfm.app.managedservices.ManagedServicesClient.CLIENT_ID;
+import static org.kie.baaas.dfm.app.managedservices.ManagedServicesClient.CLIENT_SECRET;
+
+public class ManagedKafkaService implements KafkaService {
+    private ManagedServicesClient managedServicesClient;
+    private VaultService vaultService;
+    private static final String CREDENTIALS_NAME = "daas-%s-credentials";
+
+    public ManagedKafkaService(ManagedServicesClient managedServicesClient, VaultService vaultService) {
+        this.managedServicesClient = managedServicesClient;
+        this.vaultService = vaultService;
+    }
+
+    public Credential getCustomerCredential(String customerId) {
+        String secretName = String.format(CREDENTIALS_NAME, customerId);
+        Secret secret = vaultService.get(secretName);
+        if (secret == null) {
+            secret = managedServicesClient.createOrReplaceServiceAccount(secretName);
+            vaultService.create(secret);
+        }
+        return toCredential(secret);
+    }
+
+    private Credential toCredential(Secret secret) {
+        if (secret == null || secret.getValues() == null) {
+            return null;
+        }
+        return new Credential()
+                .setClientId(secret.getValues().get(CLIENT_ID))
+                .setClientSecret(secret.getValues().get(CLIENT_SECRET));
+    }
+
+}

--- a/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/manager/kafkaservice/OperateFirstKafkaService.java
+++ b/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/manager/kafkaservice/OperateFirstKafkaService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.kie.baaas.dfm.app.manager.kafkaservice;
+
+import org.kie.baaas.dfm.app.manager.KafkaService;
+import org.kie.baaas.dfm.app.model.eventing.Credential;
+
+public class OperateFirstKafkaService implements KafkaService {
+    @Override
+    public Credential getCustomerCredential(String customerId) {
+        throw new KafkaServiceNotSupportedException("OperateFirstKafkaService is currently not defined.");
+    }
+}

--- a/baaas-decision-fleet-manager/src/main/resources/application.properties
+++ b/baaas-decision-fleet-manager/src/main/resources/application.properties
@@ -38,9 +38,13 @@ baaas.dfm.secrets-manager.aws.region=${BAAAS_DFM_AWS_REGION}
 baaas.dfm.secrets-manager.aws.endpoint-override=${BAAAS_DFM_AWS_SECRETSMANAGER_ADDRESS:}
 baaas.dfm.secrets-manager.aws.access-key-id=${AWS_ACCESS_KEY_ID}
 baaas.dfm.secrets-manager.aws.secret-access-key=${AWS_SECRET_ACCESS_KEY}
+
 # Decision Request validation
 # -1 to disable, >= 0 for the number of allowed decisions
 baaas.dfm.max.allowed.decisions=${BAAAS_DFM_MAX_ALLOWED_DECISIONS:-1}
+
+# enable/disable kafka integration; managed-kafka, operate-first-kafka or disabled
+baaas.dfm.kafka.service.type=${BAAAS_DFM_KAFKA_SERVICE_TYPE:managed-kafka}
 
 # SSO
 quarkus.oidc.auth-server-url=${BAAAS_DFM_SSO_URL}
@@ -50,6 +54,8 @@ quarkus.oidc.client-id=${BAAAS_DFM_SSO_CLIENT_ID}
 quarkus.native.additional-build-args=-H:ReflectionConfigurationFiles=reflection-config.json
 ## Dev Profile Overrides
 # test
+# enable/disable kafka integration; managed-kafka, operate-first-kafka or disabled
+%dev.baaas.dfm.kafka.service.type=disabled
 %dev.baaas.kafka.bootstrap-urls=${BAAAS_KAFKA_BOOTSTRAP_SERVERS:test}
 %dev.baaas.dfs.urls.dmn-jit=http://localhost:9000/jitdmn
 %dev.baaas.dfs.urls.k8s-api=http://localhost:8443

--- a/baaas-decision-fleet-manager/src/test/java/org/kie/baaas/dfm/app/manager/DecisionLifecycleOrchestratorTest.java
+++ b/baaas-decision-fleet-manager/src/test/java/org/kie/baaas/dfm/app/manager/DecisionLifecycleOrchestratorTest.java
@@ -15,8 +15,6 @@
 
 package org.kie.baaas.dfm.app.manager;
 
-import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.kie.baaas.dfm.api.decisions.DecisionRequest;
@@ -29,13 +27,15 @@ import org.kie.baaas.dfm.app.exceptions.DecisionFleetManagerException;
 import org.kie.baaas.dfm.app.listener.ListenerManager;
 import org.kie.baaas.dfm.app.managedservices.ManagedServicesClient;
 import org.kie.baaas.dfm.app.managedservices.ManagedServicesException;
+import org.kie.baaas.dfm.app.manager.kafkaservice.KafkaServiceNotSupportedException;
+import org.kie.baaas.dfm.app.manager.kafkaservice.KafkaServiceProducer;
 import org.kie.baaas.dfm.app.model.Decision;
 import org.kie.baaas.dfm.app.model.DecisionFleetShard;
 import org.kie.baaas.dfm.app.model.DecisionVersion;
 import org.kie.baaas.dfm.app.model.deployment.Deployment;
+import org.kie.baaas.dfm.app.model.eventing.Credential;
 import org.kie.baaas.dfm.app.model.eventing.KafkaConfig;
 import org.kie.baaas.dfm.app.storage.DecisionDMNStorage;
-import org.kie.baaas.dfm.app.vault.Secret;
 import org.kie.baaas.dfm.app.vault.VaultService;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -44,19 +44,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.openshift.cloud.api.kas.invoker.ApiException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class DecisionLifecycleOrchestratorTest {
@@ -91,6 +83,12 @@ public class DecisionLifecycleOrchestratorTest {
 
     @InjectMocks
     private DecisionLifecycleOrchestrator orchestrator;
+
+    @Mock
+    KafkaServiceProducer kafkaServiceProducer;
+
+    @Mock
+    KafkaService kafkaService;
 
     @Test
     public void createOrUpdateDecision() {
@@ -128,23 +126,21 @@ public class DecisionLifecycleOrchestratorTest {
         when(decisionManager.createOrUpdateVersion(customerId, request)).thenReturn(decisionVersion);
         when(selector.selectFleetShardForDeployment(decision)).thenReturn(fleetShard);
         when(clientFactory.createClientFor(fleetShard)).thenReturn(client);
-        Secret secret = new Secret().setId(saName).setValues(Map.of(ManagedServicesClient.CLIENT_ID, "foo", ManagedServicesClient.CLIENT_SECRET, "bar"));
-        when(managedServicesClient.createOrReplaceServiceAccount(saName)).thenReturn(secret);
+
+        when(kafkaServiceProducer.isKafkaServiceEnabled()).thenReturn(true);
+        when(kafkaService.getCustomerCredential(customerId)).thenReturn(new Credential().setClientId("client_id").setClientSecret("client_secret"));
 
         DecisionVersion created = orchestrator.createOrUpdateVersion(customerId, request);
         assertThat(created, is(notNullValue()));
         assertThat(created, equalTo(decisionVersion));
 
         verify(client).deploy(decisionVersion);
-        verify(vaultService, times(1)).get(eq(saName));
-        verify(managedServicesClient, times(1)).createOrReplaceServiceAccount(eq(saName));
-        verify(vaultService, times(1)).create(eq(secret));
+        verify(kafkaService, times(1)).getCustomerCredential(customerId);
     }
 
     @Test
     public void createOrUpdateDecisionErrorCreatingSA() {
         String customerId = "foo";
-        String saName = "daas-" + customerId + "-credentials";
         DecisionRequest request = mock(DecisionRequest.class);
 
         DecisionVersion decisionVersion = mock(DecisionVersion.class);
@@ -154,15 +150,28 @@ public class DecisionLifecycleOrchestratorTest {
         when(request.getEventing()).thenReturn(eventing);
         when(decisionVersion.getKafkaConfig()).thenReturn(new KafkaConfig());
         when(decisionManager.createOrUpdateVersion(customerId, request)).thenReturn(decisionVersion);
-        when(managedServicesClient.createOrReplaceServiceAccount(anyString()))
+        when(kafkaServiceProducer.isKafkaServiceEnabled()).thenReturn(true);
+        when(kafkaService.getCustomerCredential(anyString()))
                 .thenThrow(new ManagedServicesException("some error", new ApiException("api error")));
 
         assertThrows(ManagedServicesException.class, () -> orchestrator.createOrUpdateVersion(customerId, request));
-
         verifyNoInteractions(client);
-        verify(vaultService, times(1)).get(eq(saName));
-        verify(managedServicesClient, times(1)).createOrReplaceServiceAccount(eq(saName));
-        verify(vaultService, times(0)).create(any(Secret.class));
+    }
+
+    @Test
+    public void createOrUpdateDecision_no_supported_kafka_service() {
+        String customerId = "foo";
+        DecisionRequest request = mock(DecisionRequest.class);
+
+        Eventing eventing = new Eventing();
+        eventing.setKafka(new Kafka());
+        when(request.getEventing()).thenReturn(eventing);
+
+        when(kafkaServiceProducer.isKafkaServiceEnabled()).thenReturn(false);
+        assertThrows(KafkaServiceNotSupportedException.class, () -> orchestrator.createOrUpdateVersion(customerId, request));
+        verifyNoInteractions(kafkaService);
+        verifyNoInteractions(listenerManager);
+        verifyNoInteractions(decisionManager);
     }
 
     @Test
@@ -183,8 +192,11 @@ public class DecisionLifecycleOrchestratorTest {
         when(decisionVersion.getKafkaConfig()).thenReturn(new KafkaConfig());
         when(decisionManager.createOrUpdateVersion(customerId, request)).thenReturn(decisionVersion);
         when(selector.selectFleetShardForDeployment(decision)).thenReturn(fleetShard);
+
+        when(kafkaServiceProducer.isKafkaServiceEnabled()).thenReturn(true);
         when(clientFactory.createClientFor(fleetShard)).thenReturn(client);
-        when(vaultService.get(anyString())).thenReturn(new Secret());
+        when(kafkaService.getCustomerCredential(customerId)).thenReturn(new Credential().setClientId("client_id").setClientSecret("client_secret"));
+
         doThrow(new RuntimeException("Nope!")).when(client).deploy(decisionVersion);
 
         assertThrows(DecisionFleetManagerException.class, () -> {
@@ -192,7 +204,7 @@ public class DecisionLifecycleOrchestratorTest {
         });
 
         verify(decisionManager).failed(eq(customerId), eq(decisionId), eq(version), any(Deployment.class));
-        verify(vaultService, times(1)).get(eq("daas-" + customerId + "-credentials"));
+        verify(kafkaService, times(1)).getCustomerCredential(eq(customerId));
     }
 
     @Test

--- a/baaas-decision-fleet-manager/src/test/java/org/kie/baaas/dfm/app/manager/kafkaservice/DisabledKafkaServiceConfigTestProfile.java
+++ b/baaas-decision-fleet-manager/src/test/java/org/kie/baaas/dfm/app/manager/kafkaservice/DisabledKafkaServiceConfigTestProfile.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.kie.baaas.dfm.app.manager.kafkaservice;
+
+import java.util.Collections;
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class DisabledKafkaServiceConfigTestProfile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Collections.singletonMap("baaas.dfm.kafka.service.type", "disabled");
+    }
+}

--- a/baaas-decision-fleet-manager/src/test/java/org/kie/baaas/dfm/app/manager/kafkaservice/DisabledKafkaServiceTest.java
+++ b/baaas-decision-fleet-manager/src/test/java/org/kie/baaas/dfm/app/manager/kafkaservice/DisabledKafkaServiceTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.kie.baaas.dfm.app.manager.kafkaservice;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.kie.baaas.dfm.app.manager.KafkaService;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+@TestProfile(DisabledKafkaServiceConfigTestProfile.class)
+public class DisabledKafkaServiceTest {
+    @Inject
+    KafkaService kafkaService;
+
+    @Inject
+    KafkaServiceProducer kafkaServiceProducer;
+
+    @Test
+    void testGetCustomerCredential_with_invalid_kafka_service() {
+        boolean isKafkaDefined = kafkaServiceProducer.isKafkaServiceEnabled();
+        assertThat(isKafkaDefined, equalTo(false));
+    }
+}

--- a/baaas-decision-fleet-manager/src/test/java/org/kie/baaas/dfm/app/manager/kafkaservice/KafkaServiceProducerTest.java
+++ b/baaas-decision-fleet-manager/src/test/java/org/kie/baaas/dfm/app/manager/kafkaservice/KafkaServiceProducerTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.kie.baaas.dfm.app.manager.kafkaservice;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.kie.baaas.dfm.app.manager.KafkaService;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+public class KafkaServiceProducerTest {
+    @Inject
+    KafkaService kafkaService;
+
+    @Inject
+    KafkaServiceProducer kafkaServiceProducer;
+
+    @Test
+    void testGetCustomerCredential_with_default_managed_kafka_service() {
+        boolean isKafkaDefined = kafkaServiceProducer.isKafkaServiceEnabled();
+        assertThat(isKafkaDefined, equalTo(true));
+    }
+}

--- a/baaas-decision-fleet-manager/src/test/java/org/kie/baaas/dfm/app/manager/kafkaservice/ManagedKafkaServiceMockTest.java
+++ b/baaas-decision-fleet-manager/src/test/java/org/kie/baaas/dfm/app/manager/kafkaservice/ManagedKafkaServiceMockTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.kie.baaas.dfm.app.manager.kafkaservice;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kie.baaas.dfm.app.managedservices.ManagedServicesClient;
+import org.kie.baaas.dfm.app.managedservices.ManagedServicesException;
+import org.kie.baaas.dfm.app.model.eventing.Credential;
+import org.kie.baaas.dfm.app.vault.Secret;
+import org.kie.baaas.dfm.app.vault.VaultService;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.openshift.cloud.api.kas.invoker.ApiException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ManagedKafkaServiceMockTest {
+    @Mock
+    VaultService vaultService;
+
+    @Mock
+    ManagedServicesClient managedServicesClient;
+
+    @Test
+    void testManagedServicesClient_new_service_account() {
+        String customerId = "foo";
+        String saName = "daas-" + customerId + "-credentials";
+        ManagedKafkaService kafkaService = new ManagedKafkaService(managedServicesClient, vaultService);
+
+        Secret secret = new Secret().setId(saName).setValues(Map.of(ManagedServicesClient.CLIENT_ID, "foo", ManagedServicesClient.CLIENT_SECRET, "bar"));
+        when(managedServicesClient.createOrReplaceServiceAccount(saName)).thenReturn(secret);
+
+        Credential credential = kafkaService.getCustomerCredential(customerId);
+        assertThat(credential, is(notNullValue()));
+
+        verify(vaultService, times(1)).get(eq(saName));
+        verify(managedServicesClient, times(1)).createOrReplaceServiceAccount(eq(saName));
+        verify(vaultService, times(1)).create(eq(secret));
+    }
+
+    @Test
+    void testManagedServicesClient_error_creatingSA() {
+        String customerId = "foo";
+        String saName = "daas-" + customerId + "-credentials";
+        ManagedKafkaService kafkaService = new ManagedKafkaService(managedServicesClient, vaultService);
+
+        when(managedServicesClient.createOrReplaceServiceAccount(anyString()))
+                .thenThrow(new ManagedServicesException("some error", new ApiException("api error")));
+
+        assertThrows(ManagedServicesException.class, () -> kafkaService.getCustomerCredential(customerId));
+
+        verify(vaultService, times(1)).get(eq(saName));
+        verify(managedServicesClient, times(1)).createOrReplaceServiceAccount(eq(saName));
+        verify(vaultService, times(0)).create(any(Secret.class));
+    }
+}

--- a/baaas-decision-fleet-manager/src/test/resources/application.properties
+++ b/baaas-decision-fleet-manager/src/test/resources/application.properties
@@ -52,3 +52,6 @@ quarkus.oidc.application-type=service
 # Decision Request validation
 # -1 to disable, >= 0 for the number of allowed decisions
 baaas.dfm.max.allowed.decisions=-1
+
+# enable/disable kafka integration; managed-kafka, operate-first-kafka or disabled
+baaas.dfm.kafka.service.type=managed-kafka


### PR DESCRIPTION
Signed-off-by: Marco Yeung <myeung@redhat.com>

- Have the ability to disable Kafka Integration via configuration on a per-environment basis
- If Kafka integration is disabled for an environment and the user requests a Decision with Kafka for input/output, return a 400 Bad Request HTTP response with a clear status message

Depending on the environment where DaaS is deployed, the kafka service could be different, e.g.: operate first and c.r.h have their own support on Kafka.  For DFM, the part that varies is the way to connect to, create service accounts, and collect credential from those kafka services. Interface `KafkaService` is created to abstract these platform specific parts, and the concrete implementations such as `ManagedKafkaService` or `OperateFirstKafkaService` can impl. their platform specific logics.

In `applicaiton.properties', with `baaas.dfm.kafka.service.type`, we can set to either `managed-kafka` or `operate-first-kafka for supported kafka service in that environment. To disable the kafka service at all for an environment, set the property to `none`.  If a user requests a Decision with Kafka info.  in a environment with no kafka service is set (ie: set to `none`), a 400 will be returned back.



