### PR TITLE
BAAAS-303 - Refactoring parameters and method order

### DIFF
--- a/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/controller/DecisionResource.java
+++ b/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/controller/DecisionResource.java
@@ -153,7 +153,7 @@ public class DecisionResource {
     @Path("{decisionNameOrId}/versions")
     @Authenticated
     public Response listDecisionVersions(@PathParam("decisionNameOrId") String decisionNameOrId, @DefaultValue(PAGE_DEFAULT) @Min(PAGE_MIN) @QueryParam(PAGE) int page,
-                                         @DefaultValue(SIZE_DEFAULT) @Min(SIZE_MIN) @Max(SIZE_MAX) @QueryParam(SIZE) int size) {
+            @DefaultValue(SIZE_DEFAULT) @Min(SIZE_MIN) @Max(SIZE_MAX) @QueryParam(SIZE) int size) {
         String customerId = customerIdResolver.getCustomerId(identity.getPrincipal());
         LOGGER.info("Listing all versions for Decision with id or name '{}' for customer '{}'...", decisionNameOrId, customerId);
         ListResult<DecisionVersion> versions = decisionLifecycle.listDecisionVersions(customerId, decisionNameOrId, page, size);

--- a/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/controller/DecisionResource.java
+++ b/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/controller/DecisionResource.java
@@ -98,107 +98,6 @@ public class DecisionResource {
         this.decisionMapper = decisionMapper;
     }
 
-    private Response mapDecisionVersion(DecisionVersion decisionVersion) {
-        DecisionResponse response = decisionMapper.mapVersionToDecisionResponse(decisionVersion);
-        return Response.ok(response).build();
-    }
-
-    @PUT
-    @Path("{id}/versions/{version}")
-    @Authenticated
-    public Response setCurrentVersion(@PathParam("id") String id, @PathParam("version") long version) {
-        return Response.status(400).entity("This endpoint/feature has been temporary disabled. See https://issues.redhat.com/browse/BAAAS-156").build();
-        //        String customerId = customerIdResolver.getCustomerId();
-        //        LOGGER.info("Setting new current version '{}' of Decision with id or name '{}' for customer '{}'...", id, version, customerId);
-        //        DecisionVersion decisionVersion = decisionLifecycle.setCurrentVersion(customerId, id, version);
-        //        return mapDecisionVersion(decisionVersion);
-    }
-
-    @DELETE
-    @Path("{id}")
-    @Authenticated
-    public Response deleteDecision(@PathParam("id") String id) {
-        String customerId = customerIdResolver.getCustomerId(identity.getPrincipal());
-        LOGGER.info("Deleting decision with id or name '{}' for customer id '{}'...", id, customerId);
-        decisionLifecycle.deleteDecision(customerId, id);
-        return Response.ok().build();
-    }
-
-    @DELETE
-    @Path("{id}/versions/{version}")
-    @Authenticated
-    public Response deleteDecisionVersion(@PathParam("id") String id, @PathParam("version") long version) {
-        String customerId = customerIdResolver.getCustomerId(identity.getPrincipal());
-        LOGGER.info("Deleting version '{}' of Decision with id or name '{}' for customer '{}'...",
-                version, id, customerId);
-
-        DecisionVersion decisionVersion = decisionLifecycle.deleteVersion(customerId, id, version);
-        return mapDecisionVersion(decisionVersion);
-    }
-
-    @GET
-    @Path("{id}/versions/{version}/dmn")
-    @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    @Authenticated
-    public Response getDecisionVersionDMN(@PathParam("id") String id, @PathParam("version") long version) {
-        // TODO returns a formatted xml file.
-
-        String customerId = customerIdResolver.getCustomerId(identity.getPrincipal());
-        LOGGER.info("Requesting Decision version '{}' of with id or name '{}' for customer '{}' to be downloaded...",
-                version, id, customerId);
-
-        ByteArrayOutputStream byteArrayOutputStream = decisionLifecycle.getDMN(customerId, id, version);
-
-        Response.ResponseBuilder response = Response.ok((StreamingOutput) output -> byteArrayOutputStream.writeTo(output));
-        response.header("Content-Disposition", "attachment;filename=" + id + ".xml");
-        response.header("Content-Type", MediaType.APPLICATION_XML);
-
-        return response.build();
-    }
-
-    @GET
-    @Path("{id}/building")
-    @Authenticated
-    public Response getBuildingVersion(@PathParam("id") String decisionIdOrName) {
-        String customerId = customerIdResolver.getCustomerId(identity.getPrincipal());
-        LOGGER.info("Getting details of BUILDING version of Decision with id or name '{}' for customer '{}'...", decisionIdOrName, customerId);
-
-        DecisionVersion decisionVersion = decisionLifecycle.getBuildingVersion(customerId, decisionIdOrName);
-        return mapDecisionVersion(decisionVersion);
-    }
-
-    @GET
-    @Path("{id}/versions/{version}")
-    @Authenticated
-    public Response getDecisionVersion(@PathParam("id") String id, @PathParam("version") long version) {
-        String customerId = customerIdResolver.getCustomerId(identity.getPrincipal());
-        LOGGER.info("Getting details of Decision Version '{}' for Decision with id or name '{}' for customer '{}'...", id, version, customerId);
-        DecisionVersion decisionVersion = decisionLifecycle.getVersion(customerId, id, version);
-        return mapDecisionVersion(decisionVersion);
-    }
-
-    @GET
-    @Path("{id}")
-    @Authenticated
-    public Response getDecision(@PathParam("id") String id) {
-        String customerId = customerIdResolver.getCustomerId(identity.getPrincipal());
-        LOGGER.info("Getting details of '{}' version of Decision with id or name '{}' for customer '{}'...", DecisionVersionStatus.CURRENT, id, customerId);
-        DecisionVersion decisionVersion = decisionLifecycle.getCurrentVersion(customerId, id);
-        return mapDecisionVersion(decisionVersion);
-    }
-
-    @GET
-    @Path("{id}/versions")
-    @Authenticated
-    public Response listDecisionVersions(@PathParam("id") String id, @DefaultValue(PAGE_DEFAULT) @Min(PAGE_MIN) @QueryParam(PAGE) int page,
-            @DefaultValue(SIZE_DEFAULT) @Min(SIZE_MIN) @Max(SIZE_MAX) @QueryParam(SIZE) int size) {
-        String customerId = customerIdResolver.getCustomerId(identity.getPrincipal());
-        LOGGER.info("Listing all versions for Decision with id or name '{}' for customer '{}'...", id, customerId);
-        ListResult<DecisionVersion> versions = decisionLifecycle.listDecisionVersions(customerId, id, page, size);
-        DecisionResponseList responseList = decisionMapper.mapVersionsToDecisionResponseList(versions);
-        return Response.ok(responseList).build();
-    }
-
     @GET
     @Authenticated
     public Response listDecisions(@DefaultValue(PAGE_DEFAULT) @Min(PAGE_MIN) @QueryParam(PAGE) int page, @DefaultValue(SIZE_DEFAULT) @Min(SIZE_MIN) @Max(SIZE_MAX) @QueryParam(SIZE) int size) {
@@ -219,4 +118,104 @@ public class DecisionResource {
         return Response.status(Response.Status.CREATED).entity(decisionResponse).build();
     }
 
+    @GET
+    @Path("{decisionNameOrId}")
+    @Authenticated
+    public Response getDecision(@PathParam("decisionNameOrId") String decisionNameOrId) {
+        String customerId = customerIdResolver.getCustomerId(identity.getPrincipal());
+        LOGGER.info("Getting details of '{}' version of Decision with id or name '{}' for customer '{}'...", DecisionVersionStatus.CURRENT, decisionNameOrId, customerId);
+        DecisionVersion decisionVersion = decisionLifecycle.getCurrentVersion(customerId, decisionNameOrId);
+        return mapDecisionVersion(decisionVersion);
+    }
+
+    @DELETE
+    @Path("{decisionNameOrId}")
+    @Authenticated
+    public Response deleteDecision(@PathParam("decisionNameOrId") String decisionNameOrId) {
+        String customerId = customerIdResolver.getCustomerId(identity.getPrincipal());
+        LOGGER.info("Deleting decision with id or name '{}' for customer id '{}'...", decisionNameOrId, customerId);
+        decisionLifecycle.deleteDecision(customerId, decisionNameOrId);
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("{decisionNameOrId}/building")
+    @Authenticated
+    public Response getBuildingVersion(@PathParam("decisionNameOrId") String decisionIdOrName) {
+        String customerId = customerIdResolver.getCustomerId(identity.getPrincipal());
+        LOGGER.info("Getting details of BUILDING version of Decision with id or name '{}' for customer '{}'...", decisionIdOrName, customerId);
+
+        DecisionVersion decisionVersion = decisionLifecycle.getBuildingVersion(customerId, decisionIdOrName);
+        return mapDecisionVersion(decisionVersion);
+    }
+
+    @GET
+    @Path("{decisionNameOrId}/versions")
+    @Authenticated
+    public Response listDecisionVersions(@PathParam("decisionNameOrId") String decisionNameOrId, @DefaultValue(PAGE_DEFAULT) @Min(PAGE_MIN) @QueryParam(PAGE) int page,
+                                         @DefaultValue(SIZE_DEFAULT) @Min(SIZE_MIN) @Max(SIZE_MAX) @QueryParam(SIZE) int size) {
+        String customerId = customerIdResolver.getCustomerId(identity.getPrincipal());
+        LOGGER.info("Listing all versions for Decision with id or name '{}' for customer '{}'...", decisionNameOrId, customerId);
+        ListResult<DecisionVersion> versions = decisionLifecycle.listDecisionVersions(customerId, decisionNameOrId, page, size);
+        DecisionResponseList responseList = decisionMapper.mapVersionsToDecisionResponseList(versions);
+        return Response.ok(responseList).build();
+    }
+
+    @GET
+    @Path("{decisionNameOrId}/versions/{version}")
+    @Authenticated
+    public Response getDecisionVersion(@PathParam("decisionNameOrId") String decisionNameOrId, @PathParam("version") long version) {
+        String customerId = customerIdResolver.getCustomerId(identity.getPrincipal());
+        LOGGER.info("Getting details of Decision Version '{}' for Decision with id or name '{}' for customer '{}'...", decisionNameOrId, version, customerId);
+        DecisionVersion decisionVersion = decisionLifecycle.getVersion(customerId, decisionNameOrId, version);
+        return mapDecisionVersion(decisionVersion);
+    }
+
+    @PUT
+    @Path("{decisionNameOrId}/versions/{version}")
+    @Authenticated
+    public Response setCurrentVersion(@PathParam("decisionNameOrId") String decisionNameOrId, @PathParam("version") long version) {
+        return Response.status(400).entity("This endpoint/feature has been temporary disabled. See https://issues.redhat.com/browse/BAAAS-156").build();
+        //        String customerId = customerIdResolver.getCustomerId();
+        //        LOGGER.info("Setting new current version '{}' of Decision with id or name '{}' for customer '{}'...", id, version, customerId);
+        //        DecisionVersion decisionVersion = decisionLifecycle.setCurrentVersion(customerId, id, version);
+        //        return mapDecisionVersion(decisionVersion);
+    }
+
+    @DELETE
+    @Path("{decisionNameOrId}/versions/{version}")
+    @Authenticated
+    public Response deleteDecisionVersion(@PathParam("decisionNameOrId") String decisionNameOrId, @PathParam("version") long version) {
+        String customerId = customerIdResolver.getCustomerId(identity.getPrincipal());
+        LOGGER.info("Deleting version '{}' of Decision with id or name '{}' for customer '{}'...",
+                version, decisionNameOrId, customerId);
+
+        DecisionVersion decisionVersion = decisionLifecycle.deleteVersion(customerId, decisionNameOrId, version);
+        return mapDecisionVersion(decisionVersion);
+    }
+
+    @GET
+    @Path("{decisionNameOrId}/versions/{version}/dmn")
+    @Produces(MediaType.APPLICATION_OCTET_STREAM)
+    @Authenticated
+    public Response getDecisionVersionDMN(@PathParam("decisionNameOrId") String decisionNameOrId, @PathParam("version") long version) {
+        // TODO returns a formatted xml file.
+
+        String customerId = customerIdResolver.getCustomerId(identity.getPrincipal());
+        LOGGER.info("Requesting Decision version '{}' of with id or name '{}' for customer '{}' to be downloaded...",
+                version, decisionNameOrId, customerId);
+
+        ByteArrayOutputStream byteArrayOutputStream = decisionLifecycle.getDMN(customerId, decisionNameOrId, version);
+
+        Response.ResponseBuilder response = Response.ok((StreamingOutput) output -> byteArrayOutputStream.writeTo(output));
+        response.header("Content-Disposition", "attachment;filename=" + decisionNameOrId + ".xml");
+        response.header("Content-Type", MediaType.APPLICATION_XML);
+
+        return response.build();
+    }
+
+    private Response mapDecisionVersion(DecisionVersion decisionVersion) {
+        DecisionResponse response = decisionMapper.mapVersionToDecisionResponse(decisionVersion);
+        return Response.ok(response).build();
+    }
 }

--- a/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/controller/WebhookResource.java
+++ b/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/controller/WebhookResource.java
@@ -83,6 +83,20 @@ public class WebhookResource {
         this.webhookManager = listenerManager;
     }
 
+    @GET
+    @Authenticated
+    public Response getWebooks(@QueryParam(PAGE) @Min(PAGE_MIN) @DefaultValue(PAGE_DEFAULT) int page, @QueryParam(SIZE) @DefaultValue(SIZE_DEFAULT) @Min(SIZE_MIN) @Max(SIZE_MAX) int size) {
+        String customerId = customerIdResolver.getCustomerId(identity.getPrincipal());
+        ListResult<Webhook> listResult = webhookManager.listCustomerWebhooks(customerId, page, size);
+        List<WebhookResponse> webhooks = listResult.getItems().stream().map(e -> WebhookResponse.from(e.getId(), e.getUrl())).collect(Collectors.toList());
+        WebhookResponseList result = new WebhookResponseList();
+        result.setItems(webhooks);
+        result.setPage(listResult.getPage());
+        result.setSize(listResult.getSize());
+        result.setTotal(listResult.getTotal());
+        return Response.ok().entity(result).build();
+    }
+
     @POST
     @Authenticated
     public Response registerWebhook(WebhookRegistrationRequest webhookReq) {
@@ -106,19 +120,5 @@ public class WebhookResource {
         String customerId = customerIdResolver.getCustomerId(identity.getPrincipal());
         webhookManager.unregisterForWebhook(customerId, lookupRef);
         return Response.ok().build();
-    }
-
-    @GET
-    @Authenticated
-    public Response getWebooks(@QueryParam(PAGE) @Min(PAGE_MIN) @DefaultValue(PAGE_DEFAULT) int page, @QueryParam(SIZE) @DefaultValue(SIZE_DEFAULT) @Min(SIZE_MIN) @Max(SIZE_MAX) int size) {
-        String customerId = customerIdResolver.getCustomerId(identity.getPrincipal());
-        ListResult<Webhook> listResult = webhookManager.listCustomerWebhooks(customerId, page, size);
-        List<WebhookResponse> webhooks = listResult.getItems().stream().map(e -> WebhookResponse.from(e.getId(), e.getUrl())).collect(Collectors.toList());
-        WebhookResponseList result = new WebhookResponseList();
-        result.setItems(webhooks);
-        result.setPage(listResult.getPage());
-        result.setSize(listResult.getSize());
-        result.setTotal(listResult.getTotal());
-        return Response.ok().entity(result).build();
     }
 }

--- a/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/dfs/callbacks/DecisionFleetShardCallbackResource.java
+++ b/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/dfs/callbacks/DecisionFleetShardCallbackResource.java
@@ -68,8 +68,8 @@ public class DecisionFleetShardCallbackResource {
     }
 
     @POST
-    @Path("decisions/{id}/versions/{version}")
-    public Response processCallback(Webhook webhook, @PathParam("id") String decisionIdOrName, @PathParam("version") long version) {
+    @Path("decisions/{decisionNameOrId}/versions/{version}")
+    public Response processCallback(Webhook webhook, @PathParam("decisionNameOrId") String decisionIdOrName, @PathParam("version") long version) {
 
         LOGGER.info("Received callback for decision with idOrName '{}' at version '{}' for customer '{}'. Phase: '{}'", decisionIdOrName, version, webhook.getCustomer(), webhook.getPhase());
 

--- a/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/manager/DecisionManager.java
+++ b/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/manager/DecisionManager.java
@@ -151,7 +151,6 @@ public class DecisionManager implements DecisionLifecycle {
         return updateDecision(customerId, decision, decisionRequest);
     }
 
-
     /**
      * Callback method invoked when we have failed to deploy the specified version of a Decision.
      *

--- a/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/manager/DecisionManager.java
+++ b/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/manager/DecisionManager.java
@@ -68,29 +68,6 @@ public class DecisionManager implements DecisionLifecycle {
         this.decisionDMNStorage = decisionDMNStorage;
     }
 
-    /*
-     * Checks to see that we are not already performing a lifecycle operation for this Decision.
-     * Currently we only support sequential lifecycle operations.
-     */
-    private void checkForExistingLifecycleOperation(Decision decision) {
-        if (decision.getNextVersion() != null) {
-            if (DecisionVersionStatus.BUILDING.equals(decision.getNextVersion().getStatus())) {
-                throw new DecisionLifecycleException(
-                        "A lifecycle operation is already in progress for Version '" + decision.getCurrentVersion().getVersion() + "' of Decision '" + decision.getName() + "'");
-            }
-        }
-    }
-
-    private NoSuchDecisionVersionException decisionVersionDoesNotExist(String customerId, String idOrName, long version) {
-        String message = String.format("Version '%s' of Decision with id or name '%s' does not exist for customer '%s", customerId, idOrName, version);
-        throw new NoSuchDecisionVersionException(message);
-    }
-
-    private NoSuchDecisionException decisionDoesNotExist(String customerId, String idOrName) {
-        String message = String.format("Decision with id or name '%s' does not exist for customer '%s'", idOrName, customerId);
-        return new NoSuchDecisionException(message);
-    }
-
     /**
      * Gets the specified version of the decision for the given customer.
      *
@@ -99,6 +76,7 @@ public class DecisionManager implements DecisionLifecycle {
      * @param decisionVersion - The version of the Decision
      * @return - The Decision Version
      */
+    @Override
     public DecisionVersion getVersion(String customerId, String decisionIdOrName, long decisionVersion) {
         return findDecisionVersion(customerId, decisionIdOrName, decisionVersion);
     }
@@ -110,6 +88,7 @@ public class DecisionManager implements DecisionLifecycle {
      * @param decisionIdOrName - the decision id or name
      * @return - The decision version
      */
+    @Override
     public DecisionVersion getCurrentVersion(String customerId, String decisionIdOrName) {
         DecisionVersion decisionVersion = decisionVersionDAO.getCurrentVersion(customerId, decisionIdOrName);
         if (decisionVersion == null) {
@@ -125,6 +104,7 @@ public class DecisionManager implements DecisionLifecycle {
      * @param decisionIdOrName - The decision id or name
      * @return - The list of versions.
      */
+    @Override
     public ListResult<DecisionVersion> listDecisionVersions(String customerId, String decisionIdOrName, int page, int pageSize) {
 
         ListResult<DecisionVersion> versions = decisionVersionDAO.listByCustomerAndDecisionIdOrName(customerId, decisionIdOrName, page, pageSize);
@@ -140,6 +120,7 @@ public class DecisionManager implements DecisionLifecycle {
      * @param customerId - The customer id to find decisions for
      * @return - The list of decisions for this customer.
      */
+    @Override
     public ListResult<Decision> listDecisions(String customerId, int page, int pageSize) {
         ListResult<DecisionVersion> versions = decisionVersionDAO.listCurrentByCustomerId(customerId, page, pageSize);
         List<Decision> decisions = versions.getItems().stream().map((version) -> version.getDecision()).collect(toList());
@@ -161,12 +142,198 @@ public class DecisionManager implements DecisionLifecycle {
      * @param decisionRequest - The API processed request
      * @return - the updated Decision
      */
+    @Override
     public DecisionVersion createOrUpdateVersion(String customerId, DecisionRequest decisionRequest) {
         Decision decision = decisionDAO.findByCustomerAndName(customerId, decisionRequest.getName());
         if (decision == null) {
             return createDecision(customerId, decisionRequest);
         }
         return updateDecision(customerId, decision, decisionRequest);
+    }
+
+
+    /**
+     * Callback method invoked when we have failed to deploy the specified version of a Decision.
+     *
+     * @param customerId - The id of the customer that owns the decision
+     * @param decisionIdOrName - The id or the name of the DecisionVersion
+     * @param version - The version of the decision deployed
+     * @param deployment - The deployment for the DecisionVersion
+     * @return - The updated Decision with the result of the failure recorded.
+     */
+    @Override
+    public DecisionVersion failed(String customerId, String decisionIdOrName, long version, Deployment deployment) {
+
+        DecisionVersion decisionVersion = findDecisionVersion(customerId, decisionIdOrName, version);
+        Decision decision = decisionVersion.getDecision();
+        verifyCorrectVersionForCallback(decision, decisionVersion.getVersion(), DecisionVersionStatus.BUILDING);
+        decisionVersion.setDeployment(deployment);
+
+        decisionVersion.setStatus(DecisionVersionStatus.FAILED);
+        decision.setNextVersion(null);
+
+        /*
+         * In the case of multiple failures in a row, make the most recent failure the CURRENT
+         * one.
+         */
+        if (DecisionVersionStatus.FAILED == decision.getCurrentVersion().getStatus()) {
+            if (decision.getCurrentVersion().getVersion() != decisionVersion.getVersion()) {
+                decision.setCurrentVersion(decisionVersion);
+            }
+        }
+
+        LOGGER.info("Marked version '{}' of Decision '{}' as FAILED for customer id '{}", decisionVersion.getVersion(), decision.getName(), customerId);
+
+        return decisionVersion;
+    }
+
+    /**
+     * Callback method invoked when we have deployed the specified version of a Decision.
+     *
+     * @param customerId - The id of the customer that owns the decision
+     * @param decisionIdOrName - The id or the name of the decisionVersion that has been deployed
+     * @param version - The version of the decision deployed
+     * @param deployment - The deployment record.
+     * @return - The updated Decision with the result of the deployment recorded.
+     */
+    @Override
+    public DecisionVersion deployed(String customerId, String decisionIdOrName, long version, Deployment deployment) {
+
+        DecisionVersion decisionVersion = findDecisionVersion(customerId, decisionIdOrName, version);
+        Decision decision = decisionVersion.getDecision();
+        verifyCorrectVersionForCallback(decision, decisionVersion.getVersion(), DecisionVersionStatus.BUILDING);
+
+        decisionVersion.setDeployment(deployment);
+        decisionVersion.setStatus(DecisionVersionStatus.CURRENT);
+        decisionVersion.setPublishedAt(ZonedDateTime.now(ZoneOffset.UTC));
+
+        DecisionVersion currentVersion = decision.getCurrentVersion();
+        if (currentVersion.getVersion() != decisionVersion.getVersion()) {
+            currentVersion.setStatus(DecisionVersionStatus.READY);
+        }
+
+        decision.setCurrentVersion(decisionVersion);
+        decision.setNextVersion(null);
+
+        LOGGER.info("Marked version '{}' of Decision '{}' as CURRENT for customer id '{}", decisionVersion.getVersion(), decision.getName(), customerId);
+
+        return decisionVersion;
+    }
+
+    /**
+     * Begin the process of moving the "current" endpoint to the specified decision version.
+     *
+     * @param customerId - The customer that owns the decision
+     * @param decisionIdOrName - The id or name of the decision
+     * @param version - The version to use in the CURRENT endpoint
+     * @return - The Decision Version we are attempting to use as current one.
+     */
+    @Override
+    public DecisionVersion setCurrentVersion(String customerId, String decisionIdOrName, long version) {
+        DecisionVersion decisionVersion = findDecisionVersion(customerId, decisionIdOrName, version);
+        checkForExistingLifecycleOperation(decisionVersion.getDecision());
+
+        if (!DecisionVersionStatus.READY.equals(decisionVersion.getStatus())) {
+            throw new DecisionLifecycleException(
+                    "Cannot move the current pointer to version '" + version + "' of decision '" + decisionIdOrName + "' as it is in state '" + decisionVersion.getStatus() + "'");
+        }
+
+        decisionVersion.setStatus(DecisionVersionStatus.BUILDING);
+        decisionVersion.getDecision().setNextVersion(decisionVersion);
+        return decisionVersion;
+    }
+
+    /**
+     * Reads the given dmn version and name from associated customerId
+     *
+     * @param customerId - The customer that owns the Decision
+     * @param decisionNameOrId - The name or the id of the decision to be returned
+     * @param version - The version of the decision to be returned
+     * @return - The dmn as String from S3 bucket
+     */
+    @Override
+    public ByteArrayOutputStream getDMN(String customerId, String decisionNameOrId, long version) {
+
+        DecisionVersion decisionVersion = findDecisionVersion(customerId, decisionNameOrId, version);
+        return decisionDMNStorage.readDMN(customerId, decisionVersion);
+    }
+
+    /**
+     * Attempts to delete the specified version of a Decision
+     *
+     * @param customerId - The customer that owns the Decision
+     * @param decisionNameOrId - The name or the id of the Decision to delete the version from
+     * @param version - The version of the Decision to delete.
+     * @return - The deleted version of the Decision.
+     */
+    @Override
+    public DecisionVersion deleteVersion(String customerId, String decisionNameOrId, long version) {
+        DecisionVersion decisionVersion = findDecisionVersion(customerId, decisionNameOrId, version);
+
+        // Can't delete a version whilst it is current
+        if (DecisionVersionStatus.CURRENT == decisionVersion.getStatus()) {
+            throw new DecisionLifecycleException("It is not valid to delete the 'CURRENT' version of Decision '" + decisionNameOrId + "' for customer id '" + customerId + "'");
+        }
+
+        // Deleting a DecisionVersion is a logical delete. They should still appear in history.
+        decisionVersion.setStatus(DecisionVersionStatus.DELETED);
+        return decisionVersion;
+    }
+
+    /**
+     * Deletes the specified decision fully
+     *
+     * @param customerId - The customer that owns the decision
+     * @param decisionNameOrId - The name or the id of the Decision to delete.
+     * @return - The deleted decision.
+     */
+    @Override
+    public Decision deleteDecision(String customerId, String decisionNameOrId) {
+
+        Decision decision = decisionDAO.findByCustomerAndIdOrName(customerId, decisionNameOrId);
+        if (decision == null) {
+            throw decisionDoesNotExist(customerId, decisionNameOrId);
+        }
+
+        decisionDAO.delete(decision);
+        LOGGER.info("Deleted Decision with name '{}' and customer id '{}'", decisionNameOrId, customerId);
+        return decision;
+    }
+
+    private DecisionVersion findDecisionVersion(String customerId, String decisionNameOrId, long version) {
+        DecisionVersion decisionVersion = decisionVersionDAO.findByCustomerAndDecisionIdOrName(customerId, decisionNameOrId, version);
+        if (decisionVersion == null) {
+            Decision decision = decisionDAO.findByCustomerAndIdOrName(customerId, decisionNameOrId);
+            if (decision == null) {
+                throw decisionDoesNotExist(customerId, decisionNameOrId);
+            } else {
+                throw decisionVersionDoesNotExist(customerId, decisionNameOrId, version);
+            }
+        }
+        return decisionVersion;
+    }
+
+    /*
+     * Checks to see that we are not already performing a lifecycle operation for this Decision.
+     * Currently we only support sequential lifecycle operations.
+     */
+    private void checkForExistingLifecycleOperation(Decision decision) {
+        if (decision.getNextVersion() != null) {
+            if (DecisionVersionStatus.BUILDING.equals(decision.getNextVersion().getStatus())) {
+                throw new DecisionLifecycleException(
+                        "A lifecycle operation is already in progress for Version '" + decision.getCurrentVersion().getVersion() + "' of Decision '" + decision.getName() + "'");
+            }
+        }
+    }
+
+    private NoSuchDecisionVersionException decisionVersionDoesNotExist(String customerId, String idOrName, long version) {
+        String message = String.format("Version '%s' of Decision with id or name '%s' does not exist for customer '%s", customerId, idOrName, version);
+        throw new NoSuchDecisionVersionException(message);
+    }
+
+    private NoSuchDecisionException decisionDoesNotExist(String customerId, String idOrName) {
+        String message = String.format("Decision with id or name '%s' does not exist for customer '%s'", idOrName, customerId);
+        return new NoSuchDecisionException(message);
     }
 
     private DecisionVersion createDecisionVersion(String customerId, DecisionRequest decisionRequest) {
@@ -245,160 +412,5 @@ public class DecisionManager implements DecisionLifecycle {
                     .toString();
             throw new DecisionLifecycleException(message);
         }
-    }
-
-    /**
-     * Callback method invoked when we have failed to deploy the specified version of a Decision.
-     *
-     * @param customerId - The id of the customer that owns the decision
-     * @param decisionIdOrName - The id of the DecisionVersion
-     * @param version - The version of the decision deployed
-     * @param deployment - The deployment for the DecisionVersion
-     * @return - The updated Decision with the result of the failure recorded.
-     */
-    public DecisionVersion failed(String customerId, String decisionIdOrName, long version, Deployment deployment) {
-
-        DecisionVersion decisionVersion = findDecisionVersion(customerId, decisionIdOrName, version);
-        Decision decision = decisionVersion.getDecision();
-        verifyCorrectVersionForCallback(decision, decisionVersion.getVersion(), DecisionVersionStatus.BUILDING);
-        decisionVersion.setDeployment(deployment);
-
-        decisionVersion.setStatus(DecisionVersionStatus.FAILED);
-        decision.setNextVersion(null);
-
-        /*
-         * In the case of multiple failures in a row, make the most recent failure the CURRENT
-         * one.
-         */
-        if (DecisionVersionStatus.FAILED == decision.getCurrentVersion().getStatus()) {
-            if (decision.getCurrentVersion().getVersion() != decisionVersion.getVersion()) {
-                decision.setCurrentVersion(decisionVersion);
-            }
-        }
-
-        LOGGER.info("Marked version '{}' of Decision '{}' as FAILED for customer id '{}", decisionVersion.getVersion(), decision.getName(), customerId);
-
-        return decisionVersion;
-    }
-
-    /**
-     * Callback method invoked when we have deployed the specified version of a Decision.
-     *
-     * @param customerId - The id of the customer that owns the decision
-     * @param decisionIdOrName - The id of the decisionVersion that has been deployed
-     * @param version - The version of the decision deployed
-     * @param deployment - The deployment record.
-     * @return - The updated Decision with the result of the deployment recorded.
-     */
-    public DecisionVersion deployed(String customerId, String decisionIdOrName, long version, Deployment deployment) {
-
-        DecisionVersion decisionVersion = findDecisionVersion(customerId, decisionIdOrName, version);
-        Decision decision = decisionVersion.getDecision();
-        verifyCorrectVersionForCallback(decision, decisionVersion.getVersion(), DecisionVersionStatus.BUILDING);
-
-        decisionVersion.setDeployment(deployment);
-        decisionVersion.setStatus(DecisionVersionStatus.CURRENT);
-        decisionVersion.setPublishedAt(ZonedDateTime.now(ZoneOffset.UTC));
-
-        DecisionVersion currentVersion = decision.getCurrentVersion();
-        if (currentVersion.getVersion() != decisionVersion.getVersion()) {
-            currentVersion.setStatus(DecisionVersionStatus.READY);
-        }
-
-        decision.setCurrentVersion(decisionVersion);
-        decision.setNextVersion(null);
-
-        LOGGER.info("Marked version '{}' of Decision '{}' as CURRENT for customer id '{}", decisionVersion.getVersion(), decision.getName(), customerId);
-
-        return decisionVersion;
-    }
-
-    /**
-     * Begin the process of moving the "current" endpoint to the specified decision version.
-     *
-     * @param customerId - The customer that owns the decision
-     * @param decisionIdOrName - The id or name of the decision
-     * @param version - The version to use in the CURRENT endpoint
-     * @return - The Decision Version we are attempting to use as current one.
-     */
-    public DecisionVersion setCurrentVersion(String customerId, String decisionIdOrName, long version) {
-        DecisionVersion decisionVersion = findDecisionVersion(customerId, decisionIdOrName, version);
-        checkForExistingLifecycleOperation(decisionVersion.getDecision());
-
-        if (!DecisionVersionStatus.READY.equals(decisionVersion.getStatus())) {
-            throw new DecisionLifecycleException(
-                    "Cannot move the current pointer to version '" + version + "' of decision '" + decisionIdOrName + "' as it is in state '" + decisionVersion.getStatus() + "'");
-        }
-
-        decisionVersion.setStatus(DecisionVersionStatus.BUILDING);
-        decisionVersion.getDecision().setNextVersion(decisionVersion);
-        return decisionVersion;
-    }
-
-    /**
-     * Reads the given dmn version and name from associated customerId
-     *
-     * @param customerId - The customer that owns the Decision
-     * @param decisionName - The name of the decision to be returned
-     * @param version - The version of the decision to be returned
-     * @return - The dmn as String from S3 bucket
-     */
-    public ByteArrayOutputStream getDMN(String customerId, String decisionName, long version) {
-
-        DecisionVersion decisionVersion = findDecisionVersion(customerId, decisionName, version);
-        return decisionDMNStorage.readDMN(customerId, decisionVersion);
-    }
-
-    /**
-     * Attempts to delete the specified version of a Decision
-     *
-     * @param customerId - The customer that owns the Decision
-     * @param decisionName - The name of the Decision to delete the version from
-     * @param version - The version of the Decision to delete.
-     * @return - The deleted version of the Decision.
-     */
-    public DecisionVersion deleteVersion(String customerId, String decisionName, long version) {
-        DecisionVersion decisionVersion = findDecisionVersion(customerId, decisionName, version);
-
-        // Can't delete a version whilst it is current
-        if (DecisionVersionStatus.CURRENT == decisionVersion.getStatus()) {
-            throw new DecisionLifecycleException("It is not valid to delete the 'CURRENT' version of Decision '" + decisionName + "' for customer id '" + customerId + "'");
-        }
-
-        // Deleting a DecisionVersion is a logical delete. They should still appear in history.
-        decisionVersion.setStatus(DecisionVersionStatus.DELETED);
-        return decisionVersion;
-    }
-
-    private DecisionVersion findDecisionVersion(String customerId, String decisionName, long version) {
-        DecisionVersion decisionVersion = decisionVersionDAO.findByCustomerAndDecisionIdOrName(customerId, decisionName, version);
-        if (decisionVersion == null) {
-            Decision decision = decisionDAO.findByCustomerAndIdOrName(customerId, decisionName);
-            if (decision == null) {
-                throw decisionDoesNotExist(customerId, decisionName);
-            } else {
-                throw decisionVersionDoesNotExist(customerId, decisionName, version);
-            }
-        }
-        return decisionVersion;
-    }
-
-    /**
-     * Deletes the specified decision fully
-     *
-     * @param customerId - The customer that owns the decision
-     * @param decisionNameOrId - The name of the Decision to delete.
-     * @return - The deleted decision.
-     */
-    public Decision deleteDecision(String customerId, String decisionNameOrId) {
-
-        Decision decision = decisionDAO.findByCustomerAndIdOrName(customerId, decisionNameOrId);
-        if (decision == null) {
-            throw decisionDoesNotExist(customerId, decisionNameOrId);
-        }
-
-        decisionDAO.delete(decision);
-        LOGGER.info("Deleted Decision with name '{}' and customer id '{}'", decisionNameOrId, customerId);
-        return decision;
     }
 }


### PR DESCRIPTION
The refactoring includes: 

1) rename of the parameter `id` to `decisionNameOrId` as all the api accept the decision id or the decision name
2) Move the private methods after the public methods
3) In the *Resources.java files, re-order the methods according to the path. In this way the code is much more easy to read and understand