### PR TITLE
[BAAAS-304] Jpa query missing customerId as the criteria for decision number validation

### DIFF
--- a/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/dao/DecisionDAO.java
+++ b/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/dao/DecisionDAO.java
@@ -16,7 +16,6 @@
 package org.kie.baaas.dfm.app.dao;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.persistence.TypedQuery;
 import javax.transaction.Transactional;
 
 import org.kie.baaas.dfm.app.model.Decision;
@@ -42,8 +41,6 @@ public class DecisionDAO implements PanacheRepositoryBase<Decision, String> {
     }
 
     public long getDecisionCountByCustomerId(String customerId) {
-        Parameters params = Parameters.with("customerId", customerId);
-        TypedQuery<Long> namedQuery = getEntityManager().createNamedQuery("Decision.decisionCountByCustomerId", Long.class);
-        return namedQuery.getSingleResult();
+        return getEntityManager().createNamedQuery("Decision.decisionCountByCustomerId", Long.class).setParameter("customerId", customerId).getSingleResult();
     }
 }

--- a/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/manager/validators/MaxAllowedDecisionValidator.java
+++ b/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/manager/validators/MaxAllowedDecisionValidator.java
@@ -60,6 +60,7 @@ public class MaxAllowedDecisionValidator implements ConstraintValidator<WithinDe
             // Decision limits not enforced in this environment. Request is valid
             return true;
         }
+
         long decisionCount = decisionDAO.getDecisionCountByCustomerId(resolver.getCustomerId(identity.getPrincipal()));
         return isDecisionCountWithinLimit(decisionCount);
     }

--- a/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/model/Decision.java
+++ b/baaas-decision-fleet-manager/src/main/java/org/kie/baaas/dfm/app/model/Decision.java
@@ -38,7 +38,7 @@ import javax.persistence.Version;
 @NamedQueries({
         @NamedQuery(name = "Decision.byCustomerIdAndName", query = "from Decision where customerId=:customerId and name=:name"),
         @NamedQuery(name = "Decision.byCustomerAndIdOrName", query = "from Decision where customerId=:customerId and name=:idOrName or id=:idOrName"),
-        @NamedQuery(name = "Decision.decisionCountByCustomerId", query = "select count(d.id) from Decision d where d.customerId=customerId")
+        @NamedQuery(name = "Decision.decisionCountByCustomerId", query = "select count(d.id) from Decision d where d.customerId=:customerId")
 })
 @Entity
 @Table(name = "DECISION")

--- a/baaas-decision-fleet-manager/src/test/java/org/kie/baaas/dfm/app/manager/validators/MaxAllowedDecisionValidatorTest.java
+++ b/baaas-decision-fleet-manager/src/test/java/org/kie/baaas/dfm/app/manager/validators/MaxAllowedDecisionValidatorTest.java
@@ -33,6 +33,7 @@ import org.mockito.Mockito;
 import io.quarkus.test.junit.QuarkusMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.security.TestSecurity;
 
 import static org.kie.baaas.dfm.app.TestConstants.DEFAULT_CUSTOMER_ID;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -76,6 +77,7 @@ public class MaxAllowedDecisionValidatorTest {
 
     ConstraintValidatorContext constraintValidatorContext;
 
+    @TestSecurity(user = DEFAULT_CUSTOMER_ID)
     @Test
     void testExceedsAllowedLimit() {
         createStorageRequest();


### PR DESCRIPTION
Signed-off-by: Marco Yeung <myeung@redhat.com>

- Jpa query missing customerId as the criteria for decision number validation